### PR TITLE
feat: if call write twice or over, cmd execute only once

### DIFF
--- a/denops/@tataku/emitter/window.ts
+++ b/denops/@tataku/emitter/window.ts
@@ -17,14 +17,43 @@ const defaultOption: Option = {
   cmd: "enew",
 };
 
+const prepareWindow = async (denops: Denops, cmd: string): Promise<number> => {
+  await execute(denops, cmd);
+  const bufnr = await fn.bufnr(denops);
+  await fn.setbufvar(denops, bufnr, "&buftype", "nofile");
+  return bufnr;
+};
+
 const emitter = (denops: Denops, option = defaultOption) => {
   assert(option, isOption);
+  const state = { isPrepared: false, bufnr: -1 };
   return new WritableStream<string[]>({
     write: async (chunk: string[]) => {
-      await execute(denops, option?.cmd ?? defaultOption.cmd);
-      const bufnr = await fn.bufnr(denops);
-      await fn.setbufvar(denops, bufnr, "&buftype", "nofile");
-      await fn.setbufline(denops, bufnr, 1, chunk);
+      if (!state.isPrepared) {
+        state.bufnr = await prepareWindow(
+          denops,
+          option?.cmd ?? defaultOption.cmd,
+        );
+        state.isPrepared = true;
+      }
+      const linenr = await fn.line(denops, "$") - 1;
+      const lastLine = await fn.getbufline(denops, state.bufnr, linenr);
+      const [currentLine, ...newLines] = chunk.join("").split(/\r?\n/);
+
+      await fn.setbufline(
+        denops,
+        state.bufnr,
+        linenr,
+        lastLine + currentLine,
+      );
+      if (newLines.length > 0) {
+        await fn.appendbufline(
+          denops,
+          state.bufnr,
+          linenr,
+          newLines,
+        );
+      }
     },
   });
 };


### PR DESCRIPTION
On ollama processor, it pass word.

It call `write` multiple times.

Current implementation, open buffer on each `write` called.
